### PR TITLE
C/C++ Options, Autoformat on save, Ignore file with specific extensions.

### DIFF
--- a/astyle-extension/AStyleExtension/AStyleExtensionPackage.cs
+++ b/astyle-extension/AStyleExtension/AStyleExtensionPackage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.ComponentModel.Design;
@@ -79,12 +80,24 @@ namespace AStyleExtension {
 		private int OnBeforeDocumentSave(uint docCookie) {
 			bool csFormatOnSave = (bool)_props.Item("CsFormatOnSave").Value; ;
 			bool cppFormatOnSave = (bool)_props.Item("CppFormatOnSave").Value;
+            string cppIgnoredExtensions = (string)_props.Item("CppIgnoredFileExtensions").Value;
 
 			if (!cppFormatOnSave && !csFormatOnSave) {
 				return VSConstants.S_OK;
 			}
 
-			var doc = _dte.Documents.OfType<Document>().FirstOrDefault(x => x.FullName == _documentEventListener.GetDocumentName(docCookie));
+            var doc = _dte.Documents.OfType<Document>().FirstOrDefault(x => x.FullName == _documentEventListener.GetDocumentName(docCookie));
+            //check ignored extensions
+            if (!string.IsNullOrEmpty(cppIgnoredExtensions))
+            {
+                List<string> fileExtensionsList = new List<string>();
+                fileExtensionsList.AddRange(cppIgnoredExtensions.Split(" ".ToCharArray(), StringSplitOptions.RemoveEmptyEntries));
+                string ext = System.IO.Path.GetExtension(doc.FullName);
+                if (fileExtensionsList.Contains(ext))
+                {
+                    return VSConstants.S_OK;
+                }
+            }
 			var language = GetLanguage(doc);
 
 			if (language == Language.CSharp && csFormatOnSave) {

--- a/astyle-extension/AStyleExtension/AStyleGeneralOptionsControl.Designer.cs
+++ b/astyle-extension/AStyleExtension/AStyleGeneralOptionsControl.Designer.cs
@@ -41,10 +41,13 @@
             this.textBoxDetails = new System.Windows.Forms.TextBox();
             this.buttonImport = new System.Windows.Forms.Button();
             this.buttonExport = new System.Windows.Forms.Button();
+            this.txtIgnoredExtensions = new System.Windows.Forms.TextBox();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.tabControlOptions.SuspendLayout();
             this.tabPageCPP.SuspendLayout();
             this.tabPageCS.SuspendLayout();
             this.tabPageImport.SuspendLayout();
+            this.groupBox2.SuspendLayout();
             this.SuspendLayout();
             // 
             // tabControlOptions
@@ -60,6 +63,7 @@
             // 
             // tabPageCPP
             // 
+            this.tabPageCPP.Controls.Add(this.groupBox2);
             this.tabPageCPP.Controls.Add(this.checkBoxCppFormatOnSave);
             this.tabPageCPP.Controls.Add(this.buttonCPPEdit);
             this.tabPageCPP.Controls.Add(this.labelCPP);
@@ -96,7 +100,7 @@
             // labelCPP
             // 
             this.labelCPP.AutoSize = true;
-            this.labelCPP.Location = new System.Drawing.Point(7, 40);
+            this.labelCPP.Location = new System.Drawing.Point(9, 114);
             this.labelCPP.Name = "labelCPP";
             this.labelCPP.Size = new System.Drawing.Size(76, 13);
             this.labelCPP.TabIndex = 4;
@@ -104,12 +108,12 @@
             // 
             // textBoxCPP
             // 
-            this.textBoxCPP.Location = new System.Drawing.Point(10, 56);
+            this.textBoxCPP.Location = new System.Drawing.Point(10, 130);
             this.textBoxCPP.Multiline = true;
             this.textBoxCPP.Name = "textBoxCPP";
             this.textBoxCPP.ReadOnly = true;
             this.textBoxCPP.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.textBoxCPP.Size = new System.Drawing.Size(368, 190);
+            this.textBoxCPP.Size = new System.Drawing.Size(368, 116);
             this.textBoxCPP.TabIndex = 3;
             // 
             // buttonCPPSettings
@@ -239,6 +243,24 @@
             this.buttonExport.UseVisualStyleBackColor = true;
             this.buttonExport.Click += new System.EventHandler(this.OnButtonExportClick);
             // 
+            // txtIgnoredExtensions
+            // 
+            this.txtIgnoredExtensions.Location = new System.Drawing.Point(6, 29);
+            this.txtIgnoredExtensions.Name = "txtIgnoredExtensions";
+            this.txtIgnoredExtensions.Size = new System.Drawing.Size(354, 20);
+            this.txtIgnoredExtensions.TabIndex = 0;
+            this.txtIgnoredExtensions.Text = ".re  .y";
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.txtIgnoredExtensions);
+            this.groupBox2.Location = new System.Drawing.Point(12, 35);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(366, 67);
+            this.groupBox2.TabIndex = 15;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Ignored Extensions";
+            // 
             // AStyleGeneralOptionsControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -253,6 +275,8 @@
             this.tabPageCS.PerformLayout();
             this.tabPageImport.ResumeLayout(false);
             this.tabPageImport.PerformLayout();
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -277,6 +301,8 @@
         private System.Windows.Forms.TextBox textBoxDetails;
         private System.Windows.Forms.CheckBox checkBoxCppFormatOnSave;
         private System.Windows.Forms.CheckBox checkBoxCsFormatOnSave;
+        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.TextBox txtIgnoredExtensions;
 
 
     }

--- a/astyle-extension/AStyleExtension/AStyleGeneralOptionsControl.cs
+++ b/astyle-extension/AStyleExtension/AStyleGeneralOptionsControl.cs
@@ -10,6 +10,7 @@ namespace AStyleExtension {
         private bool _isCSarpEnabled;
         private bool _cppFormatOnSave;
         private bool _csFormatOnSave;
+        private string _cppIgnoredExtensions;
 
         public bool CppFormatOnSave {
             get {
@@ -58,6 +59,16 @@ namespace AStyleExtension {
                     tabControlOptions.TabPages.Remove(tabPageCS);
                 }
             }
+        }
+        public string CppIgnoredFileExtensions {
+            get
+            {
+                _cppIgnoredExtensions = txtIgnoredExtensions.Text;
+                return _cppIgnoredExtensions;
+            }
+            set {
+                _cppIgnoredExtensions = value;
+                txtIgnoredExtensions.Text = _cppIgnoredExtensions; }
         }
 
         public AStyleGeneralOptionsControl() {
@@ -130,6 +141,7 @@ namespace AStyleExtension {
                 CsCommandLine = CsOptions,
                 CppFormatOnSave = CppFormatOnSave,
                 CsFormatOnSave = CsFormatOnSave,
+                CppIgnoredFileExtensions = CppIgnoredFileExtensions,
                 Version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString()
             };
 
@@ -177,6 +189,7 @@ namespace AStyleExtension {
 
             CppOptions = settings.CppCommandLine;
             checkBoxCppFormatOnSave.Checked = settings.CppFormatOnSave;
+            CppIgnoredFileExtensions = settings.CppIgnoredFileExtensions;
 
             if (IsCSarpEnabled) {
                 CsOptions = settings.CsCommandLine;

--- a/astyle-extension/AStyleExtension/AStyleGeneralOptionsPage.cs
+++ b/astyle-extension/AStyleExtension/AStyleGeneralOptionsPage.cs
@@ -14,6 +14,7 @@ namespace AStyleExtension {
         public bool CppFormatOnSave { get; set; }
         public bool CsFormatOnSave { get; set; }
         public bool IsCSarpEnabled { get; set; }
+        public string CppIgnoredFileExtensions { get; set; }
 
         public AStyleGeneralOptionsPage() {
             IsCSarpEnabled = true;
@@ -26,6 +27,7 @@ namespace AStyleExtension {
 
                 if (CppOptions != null) {
                     _control.CppOptions = CppOptions;
+                    
                 }
 
                 if (CsOptions != null) {
@@ -35,6 +37,10 @@ namespace AStyleExtension {
                 _control.IsCSarpEnabled = IsCSarpEnabled;
                 _control.CppFormatOnSave = CppFormatOnSave;
                 _control.CsFormatOnSave = CsFormatOnSave;
+                if (!string.IsNullOrEmpty(CppIgnoredFileExtensions))
+                    _control.CppIgnoredFileExtensions = CppIgnoredFileExtensions;
+                else
+                    _control.CppIgnoredFileExtensions = "";
 
                 return _control;
             }
@@ -46,6 +52,7 @@ namespace AStyleExtension {
                 CsOptions = _control.CsOptions;
                 CppFormatOnSave = _control.CppFormatOnSave;
                 CsFormatOnSave = _control.CsFormatOnSave;
+                CppIgnoredFileExtensions = _control.CppIgnoredFileExtensions;
             }
 
             base.OnDeactivate(e);           
@@ -57,7 +64,7 @@ namespace AStyleExtension {
                 _control.CsOptions = CsOptions;
                 _control.CppFormatOnSave = CppFormatOnSave;
                 _control.CsFormatOnSave = CsFormatOnSave;
-
+                _control.CppIgnoredFileExtensions = CppIgnoredFileExtensions;
                 _control.ClearDetails();
             }
 
@@ -70,6 +77,7 @@ namespace AStyleExtension {
                 CsOptions = _control.CsOptions;
                 CppFormatOnSave = _control.CppFormatOnSave;
                 CsFormatOnSave = _control.CsFormatOnSave;
+                CppIgnoredFileExtensions = _control.CppIgnoredFileExtensions;
             }
 
             base.OnApply(e);

--- a/astyle-extension/AStyleExtension/AStyleSettings.cs
+++ b/astyle-extension/AStyleExtension/AStyleSettings.cs
@@ -8,5 +8,6 @@ namespace AStyleExtension {
         public string CppCommandLine { get; set; }
         public string CsCommandLine { get; set; }
         public string Version { get; set; }
+        public string CppIgnoredFileExtensions { get; set; }
     }
 }


### PR DESCRIPTION
I added the ability to ignore files with specific extension, this is useful if you want to edit a file(ex:  a parser grammar file) inside visual studio, you want the syntax highlight and you want it to be treated as a c++ document , but the extension keep breaking the format each time I hit ctrl+s.
I hope this will be useful for you too.
Thank you for this extension. it's saving me time and keeping my source file formatted before any commit, no need to use a git before commit hook anymore :)
Thanks :)

